### PR TITLE
fix(wasm-sdk): enable scroll-to-top

### DIFF
--- a/packages/wasm-sdk/docs.html
+++ b/packages/wasm-sdk/docs.html
@@ -3280,7 +3280,15 @@ const result = await sdk.identityTopUp(identityId, assetLockProof, assetLockProo
         document.querySelectorAll('a[href^="#"]').forEach(anchor => {
             anchor.addEventListener('click', function (e) {
                 e.preventDefault();
-                const target = document.querySelector(this.getAttribute('href'));
+                const href = this.getAttribute('href');
+                if (href === '#') {
+                    window.scrollTo({
+                        top: 0,
+                        behavior: 'smooth'
+                    });
+                    return;
+                }
+                const target = document.querySelector(href);
                 if (target) {
                     target.scrollIntoView({
                         behavior: 'smooth',


### PR DESCRIPTION
## Summary
- ensure docs page scroll-to-top button works by handling empty hash links in smooth scroll script

## Testing
- `npm test`
- `python3 check_documentation.py`


------
https://chatgpt.com/codex/tasks/task_e_689c8f3dcc9c83239dabfda93372a3ae