### PR TITLE
feat(wasm-sdk): add index_values parameter to contested resource vote…

### DIFF
--- a/packages/wasm-sdk/test/ui-automation/tests/query-execution.spec.js
+++ b/packages/wasm-sdk/test/ui-automation/tests/query-execution.spec.js
@@ -829,7 +829,7 @@ test.describe('WASM SDK Query Execution Tests', () => {
       },
       { 
         name: 'getContestedResourceVotersForIdentity', 
-        hasProofSupport: false, // Not working
+        hasProofSupport: true,
         needsParameters: true,
         validateFn: (result) => {
           expect(() => JSON.parse(result)).not.toThrow();


### PR DESCRIPTION
…rs query

- Add index_values parameter to get_contested_resource_voters_for_identity_with_proof_info
- Implement proper serialization of index values using bincode
- Enable proof support for getContestedResourceVotersForIdentity in tests

