### PR TITLE
feat(wasm-sdk): add broadcast_with_delay helper to mitigate DAPI race…

### DIFF
--- a/packages/wasm-sdk/src/sdk.rs
+++ b/packages/wasm-sdk/src/sdk.rs
@@ -23,7 +23,7 @@ use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::time::Duration;
 use wasm_bindgen::prelude::wasm_bindgen;
-use wasm_bindgen::{JsError, JsValue};
+use wasm_bindgen::{JsError, JsValue, JsCast};
 use web_sys::{console, js_sys};
 
 #[wasm_bindgen]
@@ -120,6 +120,52 @@ impl WasmSdk {
     /// Clone the inner Sdk (not exposed to WASM)
     pub(crate) fn inner_clone(&self) -> Sdk {
         self.0.clone()
+    }
+
+    /// Broadcast state transition with a delay before waiting for response
+    /// This helps avoid the race condition in DAPI's waitForStateTransitionResult
+    pub(crate) async fn broadcast_with_delay<T, S>(
+        &self,
+        state_transition: &S,
+    ) -> Result<T, JsValue>
+    where
+        T: TryFrom<dash_sdk::dpp::state_transition::proof_result::StateTransitionProofResult>,
+        S: BroadcastStateTransition,
+    {
+        let sdk = &self.0;
+        
+        // Step 1: Broadcast the state transition
+        state_transition
+            .broadcast(sdk, None)
+            .await
+            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        
+        // Step 2: Add delay to allow transaction to propagate
+        // Use WASM-compatible timer
+        let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+            let closure = wasm_bindgen::closure::Closure::wrap(Box::new(move || {
+                resolve.call0(&JsValue::UNDEFINED).unwrap();
+            }) as Box<dyn FnMut()>);
+            
+            web_sys::window()
+                .unwrap()
+                .set_timeout_with_callback_and_timeout_and_arguments_0(
+                    closure.as_ref().unchecked_ref(),
+                    2000, // 2 seconds
+                )
+                .unwrap();
+            closure.forget();
+        });
+        
+        wasm_bindgen_futures::JsFuture::from(promise)
+            .await
+            .unwrap();
+        
+        // Step 3: Wait for the state transition result
+        state_transition
+            .wait_for_response::<T>(sdk, None)
+            .await
+            .map_err(|e| JsValue::from_str(&format!("Failed to wait for transition result: {}", e)))
     }
 }
 

--- a/packages/wasm-sdk/src/state_transitions/contracts/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/contracts/mod.rs
@@ -358,10 +358,9 @@ impl WasmSdk {
 
         // Broadcast the transition
         use dash_sdk::dpp::state_transition::proof_result::StateTransitionProofResult;
-        let result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast update: {}", e)))?;
+        let result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Extract updated contract from result
         let updated_version = match result {

--- a/packages/wasm-sdk/src/state_transitions/documents/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/documents/mod.rs
@@ -313,11 +313,10 @@ impl WasmSdk {
         )
         .map_err(|e| JsValue::from_str(&format!("Failed to create document transition: {}", e)))?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Log the result for debugging
         web_sys::console::log_1(&JsValue::from_str(
@@ -646,11 +645,10 @@ impl WasmSdk {
             ))
         })?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Convert result to JsValue based on the type
         match proof_result {
@@ -1224,11 +1222,10 @@ impl WasmSdk {
         )
         .map_err(|e| JsValue::from_str(&format!("Failed to create purchase transition: {}", e)))?;
 
-        // Broadcast the transition
-        let proof_result = transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast purchase: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&transition)
+            .await?;
 
         // Handle the proof result
         match proof_result {

--- a/packages/wasm-sdk/src/state_transitions/identity/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/identity/mod.rs
@@ -670,10 +670,9 @@ impl WasmSdk {
 
         // Broadcast the transition
         use dash_sdk::dpp::state_transition::proof_result::StateTransitionProofResult;
-        let _result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transfer: {}", e)))?;
+        let _result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Create JavaScript result object
         let result_obj = js_sys::Object::new();
@@ -1123,10 +1122,9 @@ impl WasmSdk {
 
         // Broadcast the transition
         use dash_sdk::dpp::state_transition::proof_result::StateTransitionProofResult;
-        let result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast update: {}", e)))?;
+        let result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Extract updated identity from result
         let updated_revision = match result {

--- a/packages/wasm-sdk/src/state_transitions/tokens/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/tokens/mod.rs
@@ -212,11 +212,10 @@ impl WasmSdk {
         )
         .map_err(|e| JsValue::from_str(&format!("Failed to create mint transition: {}", e)))?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result
         self.format_token_result(proof_result)
@@ -296,11 +295,10 @@ impl WasmSdk {
         )
         .map_err(|e| JsValue::from_str(&format!("Failed to create burn transition: {}", e)))?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result
         self.format_token_result(proof_result)
@@ -388,11 +386,10 @@ impl WasmSdk {
         )
         .map_err(|e| JsValue::from_str(&format!("Failed to create transfer transition: {}", e)))?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result
         self.format_token_result(proof_result)
@@ -481,11 +478,10 @@ impl WasmSdk {
         )
         .map_err(|e| JsValue::from_str(&format!("Failed to create freeze transition: {}", e)))?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result
         self.format_token_result(proof_result)
@@ -575,11 +571,10 @@ impl WasmSdk {
         )
         .map_err(|e| JsValue::from_str(&format!("Failed to create unfreeze transition: {}", e)))?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result
         self.format_token_result(proof_result)
@@ -675,11 +670,10 @@ impl WasmSdk {
             ))
         })?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result
         self.format_token_result(proof_result)
@@ -817,11 +811,10 @@ impl WasmSdk {
         )
         .map_err(|e| JsValue::from_str(&format!("Failed to create set price transition: {}", e)))?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result based on the proof result type
         match proof_result {
@@ -1017,11 +1010,10 @@ impl WasmSdk {
             ))
         })?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result
         self.format_token_result(proof_result)
@@ -1119,11 +1111,10 @@ impl WasmSdk {
         )
         .map_err(|e| JsValue::from_str(&format!("Failed to create claim transition: {}", e)))?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result
         self.format_token_result(proof_result)
@@ -1347,11 +1338,10 @@ impl WasmSdk {
             JsValue::from_str(&format!("Failed to create config update transition: {}", e))
         })?;
 
-        // Broadcast the transition
-        let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(&sdk, None)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to broadcast transition: {}", e)))?;
+        // Broadcast the transition with delay to avoid race condition
+        let proof_result = self
+            .broadcast_with_delay::<StateTransitionProofResult, _>(&state_transition)
+            .await?;
 
         // Format and return result
         self.format_token_result(proof_result)


### PR DESCRIPTION
Uses custom function with built-in delay instead of `broadcast_and_wait`, to get quicker response (i.e. don't wait for full 80 second timeout every time).

Changes test time from ~25 min:

<img width="508" height="863" alt="image" src="https://github.com/user-attachments/assets/722b7989-997d-41bc-83aa-cedd4b0a3e4a" />

To < 5 min (due to 2 tests still taking full time):
<img width="509" height="822" alt="image" src="https://github.com/user-attachments/assets/7e131ae8-8240-4dce-9039-00786acf9164" />

